### PR TITLE
fix: invoke bitmap.eraseColor before currentPage.render

### DIFF
--- a/android/src/main/java/com/songsterq/reactnative/PdfThumbnailModule.kt
+++ b/android/src/main/java/com/songsterq/reactnative/PdfThumbnailModule.kt
@@ -90,12 +90,12 @@ class PdfThumbnailModule(reactContext: ReactApplicationContext) : ReactContextBa
     val width = currentPage.width
     val height = currentPage.height
     val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+    bitmap.eraseColor(Color.WHITE)
     currentPage.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
     currentPage.close()
 
     // Some bitmaps have transparent background which results in a black thumbnail. Add a white background.
     val bitmapWhiteBG = Bitmap.createBitmap(bitmap.width, bitmap.height, bitmap.config)
-    bitmapWhiteBG.eraseColor(Color.WHITE)
     val canvas = Canvas(bitmapWhiteBG)
     canvas.drawBitmap(bitmap, 0f, 0f, null)
     bitmap.recycle()


### PR DESCRIPTION
Hi! 

I got some troubles with transparent images. Here an example:

![bug](https://github.com/songsterq/react-native-pdf-thumbnail/assets/28110542/e919e172-0877-4a7d-93af-3f93ec4c964e)

This PR fixes it. Perhaps it will be able to fix #60.