### PR TITLE
Build failed in React-Native 0.76.1 and 0.73.11

### DIFF
--- a/android/src/main/java/org/songsterq/pdfthumbnail/PdfThumbnailModule.kt
+++ b/android/src/main/java/org/songsterq/pdfthumbnail/PdfThumbnailModule.kt
@@ -98,7 +98,7 @@ class PdfThumbnailModule(reactContext: ReactApplicationContext) :
     currentPage.close()
 
     // Some bitmaps have transparent background which results in a black thumbnail. Add a white background.
-    val bitmapWhiteBG = Bitmap.createBitmap(bitmap.width, bitmap.height, bitmap.config)
+    val bitmapWhiteBG = Bitmap.createBitmap(bitmap.width, bitmap.height, bitmap.config ?: Bitmap.Config.ARGB_8888)
     val canvas = Canvas(bitmapWhiteBG)
     canvas.drawBitmap(bitmap, 0f, 0f, null)
     bitmap.recycle()


### PR DESCRIPTION
 Bug #79 
 
 While upgrading React Native from version 0.70 to 0.73, we identified that in some scenarios, the config property of a Bitmap may return null. This is likely due to changes in the image pipeline or how Bitmaps are handled in newer React Native versions.

To avoid crashes when calling Bitmap.createBitmap, we added a fallback to Bitmap.Config.ARGB_8888 in case bitmap.config is null.

This change prevents an IllegalArgumentException caused by attempting to create a bitmap with an undefined configuration.

In the Android source code (Bitmap.java), there's a comment that explains this behavior:

// GIF files generate null configs, assume ARGB_8888.
[android.googlesource.com](https://android.googlesource.com/platform/frameworks/base/%2B/3fa667e/graphics/java/android/graphics/Bitmap.java?utm_source=chatgpt.com)

This indicates that when dealing with GIF files, the bitmap config might be null, and the system defaults to ARGB_8888. Therefore, when creating a new bitmap, it's a safe practice to provide a fallback value like Bitmap.Config.ARGB_8888 to prevent exceptions such as IllegalArgumentException.